### PR TITLE
Fix stale require for removed html_to_editor_js_converter

### DIFF
--- a/lib/panda/editor/engine.rb
+++ b/lib/panda/editor/engine.rb
@@ -19,7 +19,6 @@ module Panda
       # Eager load converter classes
       config.to_prepare do
         require "panda/editor/markdown_to_editor_js_converter"
-        require "panda/editor/html_to_editor_js_converter"
       end
 
       initializer "panda_editor.assets" do |app|


### PR DESCRIPTION
## Summary
- Removes stale `require "panda/editor/html_to_editor_js_converter"` from `engine.rb`
- The `lib/` version was removed in b9890df and consolidated into `app/services/` (Zeitwerk autoloaded), but the explicit require was not removed
- This causes `LoadError` on boot in any app that depends on panda-editor

## Test plan
- [ ] Verify `bundle exec rake app:zeitwerk:check` passes in panda-cms
- [ ] Verify `Panda::Editor::HtmlToEditorJsConverter` is still available via Zeitwerk autoloading

🤖 Generated with [Claude Code](https://claude.com/claude-code)