### PR TITLE
Allow relative URLs and anchors in editor link tool

### DIFF
--- a/app/javascript/panda/editor/editor_js_config.js
+++ b/app/javascript/panda/editor/editor_js_config.js
@@ -367,6 +367,31 @@ export const getEditorConfig = (elementId, previousData, doc = document) => {
   return config
 }
 
+/**
+ * Patches LinkAutocomplete.isUrl to accept relative URLs (starting with /)
+ * and anchor links (starting with #) in addition to the default http/https/www patterns.
+ */
+export function patchLinkAutocomplete(win) {
+  const w = win || window
+  const LinkAutocomplete = w.LinkAutocomplete
+
+  if (!LinkAutocomplete || typeof LinkAutocomplete.isUrl !== 'function') {
+    console.warn('[Panda CMS] LinkAutocomplete not loaded, skipping isUrl patch')
+    return
+  }
+
+  const originalIsUrl = LinkAutocomplete.isUrl.bind(LinkAutocomplete)
+
+  LinkAutocomplete.isUrl = (str) => {
+    if (typeof str === 'string' && (str.startsWith('/') || str.startsWith('#'))) {
+      return true
+    }
+    return originalIsUrl(str)
+  }
+
+  console.debug('[Panda CMS] Patched LinkAutocomplete.isUrl for relative URLs and anchors')
+}
+
 export function initializeEditorUndo(editor, win) {
   const w = win || window
   if (w.Undo) {

--- a/app/javascript/panda/editor/editor_js_initializer.js
+++ b/app/javascript/panda/editor/editor_js_initializer.js
@@ -1,5 +1,5 @@
 import { ResourceLoader } from "./resource_loader.js"
-import { EDITOR_JS_RESOURCES, EDITOR_JS_CSS, getEditorConfig, initializeEditorUndo } from "./editor_js_config.js"
+import { EDITOR_JS_RESOURCES, EDITOR_JS_CSS, getEditorConfig, initializeEditorUndo, patchLinkAutocomplete } from "./editor_js_config.js"
 import { CSSExtractor } from "./css_extractor.js"
 
 export class EditorJSInitializer {
@@ -86,6 +86,9 @@ export class EditorJSInitializer {
           }
         }
       }
+
+      const win = this.document.defaultView || window
+      patchLinkAutocomplete(win)
 
       console.debug('[Panda CMS] All tools successfully loaded and verified')
     } catch (error) {


### PR DESCRIPTION
## Summary

- Add `patchLinkAutocomplete(win)` function to `editor_js_config.js` that monkey-patches `LinkAutocomplete.isUrl` to accept `/`-prefixed relative URLs and `#`-prefixed anchor links
- Call the patch in `EditorJSInitializer.loadResources()` after all CDN tools are loaded (covers the iframe page editor)

The upstream `@editorjs/link-autocomplete@0.1.0` only accepts `http://`, `https://`, and `www.` patterns, which means manually typing relative URLs or anchors and pressing Enter is rejected. The page search autocomplete continues to work as before.

## Test plan

- [ ] Open the page editor (iframe mode), select text, click the link icon
- [ ] Type `/get-help-now` and press Enter — should accept it
- [ ] Type `#my-section` and press Enter — should accept it
- [ ] Type `https://example.com` — should still work
- [ ] Search for a page name — autocomplete dropdown should appear and selection should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)