### PR TITLE
Widen sanitize dependency to >= 6.0

### DIFF
--- a/panda-editor.gemspec
+++ b/panda-editor.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "panda-core" # Must load before panda-editor for ModuleRegistry
   spec.add_dependency "rails", ">= 7.1"
   spec.add_dependency "redcarpet", "~> 3.6"
-  spec.add_dependency "sanitize", "~> 6.0"
+  spec.add_dependency "sanitize", ">= 6.0"
 
   # Development dependencies
   spec.add_development_dependency "factory_bot_rails", "~> 6.2"


### PR DESCRIPTION
## Summary
- Sanitize 7.0.0 has no breaking API changes — only drops Ruby < 3.1 support and bumps Nokogiri minimum
- Since panda-editor already requires Ruby >= 3.2.0, this is a safe upgrade
- Widens `~> 6.0` to `>= 6.0` to allow resolution with sanitize 7.x

## Test plan
- [ ] Existing tests pass with sanitize 7.0.0
- [ ] Verify HTML sanitization behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)