### PR TITLE
Enable smart typography in markdown-to-EditorJS pipeline

### DIFF
--- a/lib/panda/editor/markdown_to_editor_js_converter.rb
+++ b/lib/panda/editor/markdown_to_editor_js_converter.rb
@@ -28,7 +28,7 @@ module Panda
       private
 
       def markdown_to_html
-        renderer = Redcarpet::Render::HTML.new(
+        renderer = Redcarpet::Render::SmartyHTML.new(
           hard_wrap: true,
           link_attributes: {rel: "noopener noreferrer"}
         )

--- a/spec/lib/panda/editor/markdown_to_editor_js_converter_spec.rb
+++ b/spec/lib/panda/editor/markdown_to_editor_js_converter_spec.rb
@@ -390,6 +390,40 @@ RSpec.describe Panda::Editor::MarkdownToEditorJsConverter do
         end
       end
 
+      context "smart typography" do
+        it "converts -- to en dash in paragraph text" do
+          result = described_class.new("Some text -- with en dash").convert
+          blocks = result[:blocks]
+
+          expect(blocks[0][:data][:text]).to include("\u2013")
+          expect(blocks[0][:data][:text]).not_to include("--")
+        end
+
+        it "converts --- to em dash in paragraph text" do
+          result = described_class.new("Some text --- with em dash").convert
+          blocks = result[:blocks]
+
+          expect(blocks[0][:data][:text]).to include("\u2014")
+        end
+
+        it "preserves -- in fenced code blocks" do
+          markdown = "```\nvalue -- other\n```"
+          result = described_class.new(markdown).convert
+          blocks = result[:blocks]
+          code_block = blocks.find { |b| b[:type] == "code" }
+
+          expect(code_block[:data][:code]).to include("--")
+          expect(code_block[:data][:code]).not_to include("\u2013")
+        end
+
+        it "preserves -- in inline code" do
+          result = described_class.new("Use `x -- y` in your code").convert
+          blocks = result[:blocks]
+
+          expect(blocks[0][:data][:text]).to include("<code>x -- y</code>")
+        end
+      end
+
       context "hard line breaks" do
         let(:markdown) do
           "Line one  \nLine two"


### PR DESCRIPTION
## Summary
- Switch Redcarpet renderer from `HTML` to `SmartyHTML` to automatically convert ASCII punctuation to typographic equivalents (`--` → en dash, `---` → em dash, straight quotes → curly quotes, `...` → ellipsis)
- Code blocks (fenced and inline) are unaffected — Redcarpet protects them from SmartyPants processing
- Add 4 specs covering en dash, em dash, and code block preservation

## Test plan
- [x] All 35 markdown converter specs pass
- [x] Full panda-editor suite (124 examples) passes with 0 failures
- [ ] Verify typography renders correctly in browser with MCP-generated markdown content

🤖 Generated with [Claude Code](https://claude.com/claude-code)