### PR TITLE
fix: Preserve nested inline elements in HTML to EditorJS converter

### DIFF
--- a/app/services/panda/editor/html_to_editor_js_converter.rb
+++ b/app/services/panda/editor/html_to_editor_js_converter.rb
@@ -247,17 +247,17 @@ module Panda
           when "text"
             result += child.text
           when "strong", "b"
-            result += "<b>#{child.text}</b>"
+            result += "<b>#{process_inline_elements(child)}</b>"
           when "em", "i"
-            result += "<i>#{child.text}</i>"
+            result += "<i>#{process_inline_elements(child)}</i>"
           when "a"
             href = child["href"]
-            text = child.text.strip
+            inner = process_inline_elements(child)
             if href&.start_with?("mailto:")
               email = href.sub("mailto:", "")
-              result += "<a href=\"mailto:#{email}\">#{text}</a>"
+              result += "<a href=\"mailto:#{email}\">#{inner}</a>"
             else
-              result += "<a href=\"#{href}\">#{text}</a>"
+              result += "<a href=\"#{href}\">#{inner}</a>"
             end
           else
             result += if child.text?

--- a/spec/lib/panda/editor/html_to_editor_js_converter_spec.rb
+++ b/spec/lib/panda/editor/html_to_editor_js_converter_spec.rb
@@ -101,6 +101,56 @@ RSpec.describe Panda::Editor::HtmlToEditorJsConverter do
           expect(blocks[0][:data][:text]).to include('<a href="https://example.com">a link</a>')
         end
       end
+
+      context "with links inside bold" do
+        let(:html) { '<p>Text with <strong><a href="/about">About us</a></strong></p>' }
+
+        it "preserves both bold and link" do
+          blocks = subject[:blocks]
+
+          expect(blocks[0][:data][:text]).to eq('Text with <b><a href="/about">About us</a></b>')
+        end
+      end
+
+      context "with bold inside links" do
+        let(:html) { '<p>Text with <a href="/about"><strong>bold link</strong></a></p>' }
+
+        it "preserves both link and bold" do
+          blocks = subject[:blocks]
+
+          expect(blocks[0][:data][:text]).to eq('Text with <a href="/about"><b>bold link</b></a>')
+        end
+      end
+
+      context "with italic inside links" do
+        let(:html) { '<p>Click <a href="/page"><em>here</em></a> for more</p>' }
+
+        it "preserves both link and italic" do
+          blocks = subject[:blocks]
+
+          expect(blocks[0][:data][:text]).to eq('Click <a href="/page"><i>here</i></a> for more')
+        end
+      end
+
+      context "with links inside italic" do
+        let(:html) { '<p>See <em><a href="/ref">reference</a></em></p>' }
+
+        it "preserves both italic and link" do
+          blocks = subject[:blocks]
+
+          expect(blocks[0][:data][:text]).to eq('See <i><a href="/ref">reference</a></i>')
+        end
+      end
+
+      context "with deeply nested inline elements" do
+        let(:html) { '<p><strong><em><a href="/deep">deep link</a></em></strong></p>' }
+
+        it "preserves all nesting levels" do
+          blocks = subject[:blocks]
+
+          expect(blocks[0][:data][:text]).to eq('<b><i><a href="/deep">deep link</a></i></b>')
+        end
+      end
     end
 
     context "with lists" do


### PR DESCRIPTION
## Summary

- **Bug**: `process_inline_elements` used Nokogiri's `child.text` for `<strong>`, `<em>`, and `<a>` elements, which strips all nested HTML tags. For example, `<strong><a href="/about">About</a></strong>` would lose the link entirely, outputting just `<b>About</b>`.
- **Fix**: Replace `child.text` with recursive `process_inline_elements(child)` calls so nested inline markup (bold inside links, links inside bold/italic, deeply nested combinations) is preserved at any depth.
- **Tests**: Added 5 new test cases covering links inside bold, bold inside links, italic inside links, links inside italic, and deeply nested inline elements.

## Test plan

- [x] All 38 existing + new specs pass
- [ ] Verify in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)