### PR TITLE
fix: Remove duplicate EditorJS border and align radius

### DIFF
--- a/app/javascript/panda/editor/editor_js_config.js
+++ b/app/javascript/panda/editor/editor_js_config.js
@@ -21,8 +21,7 @@ if (window.PANDA_CMS_EDITOR_JS_RESOURCES) {
 export const EDITOR_JS_CSS = `
   .codex-editor {
     position: relative;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.75rem;
+    border-radius: 1rem;
     overflow: hidden;
   }
   .codex-editor::before {


### PR DESCRIPTION
## Summary
- Removes redundant `border: 1px solid #e5e7eb` from `.codex-editor` CSS (already provided by the outer Tailwind container)
- Changes `border-radius` from `0.75rem` (12px) to `1rem` (16px) to match `rounded-2xl` used by PanelComponent panels
- Eliminates visible double border and corner misalignment in the posts editor

## Test plan
- [ ] Run `bundle exec rspec` in panda-editor — all passing
- [ ] Visually verify EditorJS container borders align with surrounding panels in posts admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)