### PR TITLE
Switch to @editorjs/image for file upload support

### DIFF
--- a/app/javascript/panda/editor/editor_js_config.js
+++ b/app/javascript/panda/editor/editor_js_config.js
@@ -4,7 +4,7 @@ export const EDITOR_JS_RESOURCES = [
   "https://cdn.jsdelivr.net/npm/@editorjs/header@2.8.1",
   "https://cdn.jsdelivr.net/npm/@editorjs/nested-list@1.4.2",
   "https://cdn.jsdelivr.net/npm/@editorjs/quote@2.6.0",
-  "https://cdn.jsdelivr.net/npm/@editorjs/simple-image@1.6.0",
+  "https://cdn.jsdelivr.net/npm/@editorjs/image@2.9.3",
   "https://cdn.jsdelivr.net/npm/@editorjs/table@2.3.0",
   "https://cdn.jsdelivr.net/npm/@editorjs/embed@2.7.0",
   "https://cdn.jsdelivr.net/npm/@editorjs/link@2.6.2",
@@ -288,10 +288,17 @@ export const getEditorConfig = (elementId, previousData, doc = document) => {
         }
       },
       image: {
-        class: win.SimpleImage,
+        class: win.ImageTool,
         inlineToolbar: true,
         config: {
-          placeholder: 'Paste an image URL...'
+          endpoints: {
+            byFile: win.PANDA_CMS_EDITOR_JS_ENDPOINTS?.fileUpload
+          },
+          field: 'image',
+          types: 'image/*',
+          additionalRequestHeaders: {
+            'X-CSRF-Token': win.PANDA_CMS_CSRF_TOKEN
+          }
         }
       },
       table: {

--- a/app/javascript/panda/editor/editor_js_initializer.js
+++ b/app/javascript/panda/editor/editor_js_initializer.js
@@ -128,7 +128,7 @@ export class EditorJSInitializer {
       'nested-list': 'NestedList',
       'list': 'NestedList',
       'quote': 'Quote',
-      'simple-image': 'SimpleImage',
+      'image': 'ImageTool',
       'table': 'Table',
       'embed': 'Embed',
       'link': 'LinkTool',
@@ -260,6 +260,20 @@ export class EditorJSInitializer {
             config: {
               quotePlaceholder: 'Enter a quote',
               captionPlaceholder: 'Quote\'s author'
+            }
+          },
+          image: {
+            class: win.ImageTool,
+            inlineToolbar: true,
+            config: {
+              endpoints: {
+                byFile: win.PANDA_CMS_EDITOR_JS_ENDPOINTS?.fileUpload
+              },
+              field: 'image',
+              types: 'image/*',
+              additionalRequestHeaders: {
+                'X-CSRF-Token': csrfToken
+              }
             }
           },
           linkTool: {

--- a/lib/panda/editor/blocks/image.rb
+++ b/lib/panda/editor/blocks/image.rb
@@ -5,7 +5,7 @@ module Panda
     module Blocks
       class Image < Base
         def render
-          url = data["url"]
+          url = data.dig("file", "url") || data["url"]
           caption = sanitize(data["caption"])
           with_border = data["withBorder"]
           with_background = data["withBackground"]

--- a/spec/lib/panda/editor/blocks/image_spec.rb
+++ b/spec/lib/panda/editor/blocks/image_spec.rb
@@ -5,38 +5,97 @@ require "rails_helper"
 RSpec.describe Panda::Editor::Blocks::Image, :editorjs do
   include EditorJsHelper
 
-  let(:image_with_caption) do
-    {
-      "url" => "/path/to/image.jpg",
-      "caption" => "Beautiful sunset",
-      "withBorder" => true,
-      "withBackground" => true,
-      "stretched" => true
-    }
+  context "with legacy simple-image format (url at top level)" do
+    let(:image_with_caption) do
+      {
+        "url" => "/path/to/image.jpg",
+        "caption" => "Beautiful sunset",
+        "withBorder" => true,
+        "withBackground" => true,
+        "stretched" => true
+      }
+    end
+
+    let(:simple_image) do
+      {
+        "url" => "/path/to/image.jpg"
+      }
+    end
+
+    it "renders image with all options correctly" do
+      rendered = described_class.new(image_with_caption).render
+      expect(normalize_html(rendered)).to eq(normalize_html(
+                                               '<figure class="prose border bg-gray-100 w-full">' \
+                                                 '<img src="/path/to/image.jpg" alt="Beautiful sunset" />' \
+                                                 "<figcaption>Beautiful sunset</figcaption>" \
+                                               "</figure>"
+                                             ))
+    end
+
+    it "renders simple image correctly" do
+      rendered = described_class.new(simple_image).render
+      expect(normalize_html(rendered)).to eq(normalize_html(
+                                               '<figure class="prose">' \
+                                                 '<img src="/path/to/image.jpg" alt="" />' \
+                                               "</figure>"
+                                             ))
+    end
   end
 
-  let(:simple_image) do
-    {
-      "url" => "/path/to/image.jpg"
-    }
-  end
+  context "with @editorjs/image format (url nested under file)" do
+    let(:image_with_file_url) do
+      {
+        "file" => {"url" => "/uploads/photo.png"},
+        "caption" => "A photo",
+        "withBorder" => false,
+        "withBackground" => false,
+        "stretched" => false
+      }
+    end
 
-  it "renders image with all options correctly" do
-    rendered = described_class.new(image_with_caption).render
-    expect(normalize_html(rendered)).to eq(normalize_html(
-                                             '<figure class="prose border bg-gray-100 w-full">' \
-                                               '<img src="/path/to/image.jpg" alt="Beautiful sunset" />' \
-                                               "<figcaption>Beautiful sunset</figcaption>" \
-                                             "</figure>"
-                                           ))
-  end
+    let(:image_with_file_url_and_options) do
+      {
+        "file" => {"url" => "/uploads/photo.png"},
+        "caption" => "Styled photo",
+        "withBorder" => true,
+        "withBackground" => true,
+        "stretched" => true
+      }
+    end
 
-  it "renders simple image correctly" do
-    rendered = described_class.new(simple_image).render
-    expect(normalize_html(rendered)).to eq(normalize_html(
-                                             '<figure class="prose">' \
-                                               '<img src="/path/to/image.jpg" alt="" />' \
-                                             "</figure>"
-                                           ))
+    let(:image_with_file_url_no_caption) do
+      {
+        "file" => {"url" => "/uploads/photo.png"}
+      }
+    end
+
+    it "renders image from file.url" do
+      rendered = described_class.new(image_with_file_url).render
+      expect(normalize_html(rendered)).to eq(normalize_html(
+                                               '<figure class="prose">' \
+                                                 '<img src="/uploads/photo.png" alt="A photo" />' \
+                                                 "<figcaption>A photo</figcaption>" \
+                                               "</figure>"
+                                             ))
+    end
+
+    it "renders image from file.url with all options" do
+      rendered = described_class.new(image_with_file_url_and_options).render
+      expect(normalize_html(rendered)).to eq(normalize_html(
+                                               '<figure class="prose border bg-gray-100 w-full">' \
+                                                 '<img src="/uploads/photo.png" alt="Styled photo" />' \
+                                                 "<figcaption>Styled photo</figcaption>" \
+                                               "</figure>"
+                                             ))
+    end
+
+    it "renders image from file.url without caption" do
+      rendered = described_class.new(image_with_file_url_no_caption).render
+      expect(normalize_html(rendered)).to eq(normalize_html(
+                                               '<figure class="prose">' \
+                                                 '<img src="/uploads/photo.png" alt="" />' \
+                                               "</figure>"
+                                             ))
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Replace `@editorjs/simple-image` (URL-only) with `@editorjs/image` (native file upload UI)
- Configure the image tool to use the existing `fileUpload` endpoint with CSRF token auth
- Update tool mappings from `SimpleImage` to `ImageTool` across config and initializer
- Make the image block renderer backwards-compatible: handles both `file.url` (new) and `url` (legacy) data formats

## Related

- Companion PR in panda-cms: tastybamboo/panda-cms#311

## Test plan

- [x] All existing block specs pass (30/30)
- [x] New image spec covers `file.url` format (3 new test cases)
- [x] Legacy `url` format specs still pass (2 existing test cases)
- [ ] Manual: open page editor, add Image block via + toolbar, upload a file, save, verify render
- [ ] Manual: verify existing pages with old-format image blocks still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)