### PR TITLE
Add slugified id attributes to rendered headings

### DIFF
--- a/lib/panda/editor/blocks/header.rb
+++ b/lib/panda/editor/blocks/header.rb
@@ -7,7 +7,29 @@ module Panda
         def render
           content = sanitize(data["text"])
           level = data["level"] || 2
-          html_safe("<h#{level}>#{content}</h#{level}>")
+          slug = unique_slug(generate_slug(content))
+          html_safe(%(<h#{level} id="#{slug}">#{content}</h#{level}>))
+        end
+
+        private
+
+        def generate_slug(text)
+          text.gsub(/<[^>]+>/, "")  # Strip HTML tags
+            .strip
+            .downcase
+            .gsub(/[^a-z0-9\s-]/, "") # Remove non-alphanumeric (keep spaces/hyphens)
+            .gsub(/\s+/, "-")          # Spaces to hyphens
+            .gsub(/-+/, "-")           # Collapse multiple hyphens
+            .sub(/\A-/, "")            # Strip leading hyphen
+            .sub(/-\z/, "")            # Strip trailing hyphen
+        end
+
+        def unique_slug(slug)
+          registry = options[:slug_registry]
+          return slug unless registry
+
+          registry[slug] += 1
+          (registry[slug] > 1) ? "#{slug}-#{registry[slug]}" : slug
         end
       end
     end

--- a/lib/panda/editor/renderer.rb
+++ b/lib/panda/editor/renderer.rb
@@ -17,6 +17,7 @@ module Panda
         markdown = options.delete(:markdown) || false
         @footnote_registry = FootnoteRegistry.new(autolink_urls: autolink_urls, markdown: markdown)
         @options[:footnote_registry] = @footnote_registry
+        @options[:slug_registry] ||= Hash.new(0)
       end
 
       def render

--- a/spec/lib/panda/editor/blocks/header_spec.rb
+++ b/spec/lib/panda/editor/blocks/header_spec.rb
@@ -13,13 +13,67 @@ RSpec.describe Panda::Editor::Blocks::Header, :editorjs do
     {"text" => "Sub Header", "level" => 3}
   end
 
-  it "renders h2 headers correctly" do
+  it "renders h2 headers with slugified id" do
     rendered = described_class.new(h2_header).render
-    expect(normalize_html(rendered)).to eq(normalize_html("<h2>Main Header</h2>"))
+    expect(normalize_html(rendered)).to eq(normalize_html('<h2 id="main-header">Main Header</h2>'))
   end
 
-  it "renders h3 headers correctly" do
+  it "renders h3 headers with slugified id" do
     rendered = described_class.new(h3_header).render
-    expect(normalize_html(rendered)).to eq(normalize_html("<h3>Sub Header</h3>"))
+    expect(normalize_html(rendered)).to eq(normalize_html('<h3 id="sub-header">Sub Header</h3>'))
+  end
+
+  it "strips HTML tags from slug" do
+    data = {"text" => "Header with <b>bold</b> text", "level" => 2}
+    rendered = described_class.new(data).render
+    expect(rendered).to include('id="header-with-bold-text"')
+  end
+
+  it "removes special characters from slug" do
+    data = {"text" => "What's the benefit?", "level" => 2}
+    rendered = described_class.new(data).render
+    expect(rendered).to include('id="whats-the-benefit"')
+  end
+
+  it "collapses multiple spaces and hyphens" do
+    data = {"text" => "Bronze Partner — £1,000/year", "level" => 3}
+    rendered = described_class.new(data).render
+    expect(rendered).to include('id="bronze-partner-1000year"')
+  end
+
+  it "handles leading and trailing whitespace" do
+    data = {"text" => "  Padded Header  ", "level" => 2}
+    rendered = described_class.new(data).render
+    expect(rendered).to include('id="padded-header"')
+  end
+
+  it "defaults to level 2 when level is not specified" do
+    data = {"text" => "No Level"}
+    rendered = described_class.new(data).render
+    expect(rendered).to include("<h2")
+  end
+
+  context "with slug registry for deduplication" do
+    let(:registry) { Hash.new(0) }
+    let(:options) { {slug_registry: registry} }
+
+    it "appends suffix to duplicate headings" do
+      data = {"text" => "Amount", "level" => 2}
+      first = described_class.new(data, options).render
+      second = described_class.new(data, options).render
+      third = described_class.new(data, options).render
+
+      expect(first).to include('id="amount"')
+      expect(second).to include('id="amount-2"')
+      expect(third).to include('id="amount-3"')
+    end
+
+    it "tracks different headings independently" do
+      described_class.new({"text" => "One", "level" => 2}, options).render
+      described_class.new({"text" => "Two", "level" => 2}, options).render
+      second_one = described_class.new({"text" => "One", "level" => 2}, options).render
+
+      expect(second_one).to include('id="one-2"')
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Headings now get auto-generated `id` attributes based on their text content (e.g. `<h2 id="monthly-giving">Monthly Giving</h2>`)
- Enables anchor linking (`#monthly-giving`) across all CMS pages
- Uses a slug registry (passed via Renderer options) to deduplicate IDs when duplicate heading text appears on the same page (appends `-2`, `-3`, etc.)

## Test plan
- [x] All 139 existing specs pass
- [x] 9 header-specific specs including new deduplication tests
- [ ] Verify anchor links work on staging after deploy (neurobetter Why Donate? page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)