### PR TITLE
Pre-compute footnotes in cached_content on save

### DIFF
--- a/lib/panda/editor/blocks/header.rb
+++ b/lib/panda/editor/blocks/header.rb
@@ -19,7 +19,7 @@ module Panda
             .downcase
             .gsub(/[^a-z0-9\s-]/, "") # Remove non-alphanumeric (keep spaces/hyphens)
             .gsub(/\s+/, "-")          # Spaces to hyphens
-            .gsub(/-+/, "-")           # Collapse multiple hyphens
+            .squeeze("-")              # Collapse multiple hyphens
             .sub(/\A-/, "")            # Strip leading hyphen
             .sub(/-\z/, "")            # Strip trailing hyphen
         end

--- a/lib/panda/editor/content.rb
+++ b/lib/panda/editor/content.rb
@@ -44,10 +44,10 @@ module Panda
         if content.is_a?(String)
           begin
             parsed_content = JSON.parse(content)
-            self.cached_content = if parsed_content.is_a?(Hash) && parsed_content["blocks"].present?
-              Panda::Editor::Renderer.new(parsed_content, renderer_options).render
+            if parsed_content.is_a?(Hash) && parsed_content["blocks"].present?
+              self.cached_content = render_and_cache_with_footnotes(parsed_content, renderer_options)
             else
-              content
+              self.cached_content = content
             end
           rescue JSON::ParserError
             # If it's not JSON, treat it as plain text
@@ -55,10 +55,29 @@ module Panda
           end
         elsif content.is_a?(Hash) && content["blocks"].present?
           # Process EditorJS content
-          self.cached_content = Panda::Editor::Renderer.new(content, renderer_options).render
+          self.cached_content = render_and_cache_with_footnotes(content, renderer_options)
         else
           # For any other case, store as is
           self.cached_content = content.to_s
+        end
+      end
+
+      private
+
+      def render_and_cache_with_footnotes(parsed_content, renderer_options)
+        renderer = Panda::Editor::Renderer.new(parsed_content, renderer_options)
+        html = renderer.render
+
+        # Store structured data with pre-computed footnotes for JSONB columns,
+        # plain HTML for text columns (e.g. Post.cached_content)
+        column = self.class.column_for_attribute(:cached_content)
+        if column.type == :jsonb
+          {
+            "html" => html,
+            "footnotes" => renderer.footnote_registry.processed_footnotes
+          }
+        else
+          html
         end
       end
     end

--- a/lib/panda/editor/content.rb
+++ b/lib/panda/editor/content.rb
@@ -44,10 +44,10 @@ module Panda
         if content.is_a?(String)
           begin
             parsed_content = JSON.parse(content)
-            if parsed_content.is_a?(Hash) && parsed_content["blocks"].present?
-              self.cached_content = render_and_cache_with_footnotes(parsed_content, renderer_options)
+            self.cached_content = if parsed_content.is_a?(Hash) && parsed_content["blocks"].present?
+              render_and_cache_with_footnotes(parsed_content, renderer_options)
             else
-              self.cached_content = content
+              content
             end
           rescue JSON::ParserError
             # If it's not JSON, treat it as plain text


### PR DESCRIPTION
## Summary
- `generate_cached_content` now stores `{ "html" => rendered_html, "footnotes" => processed_footnotes }` for JSONB columns (BlockContent) instead of plain HTML
- The Renderer already processes footnotes during rendering but discards the FootnoteRegistry — this captures it
- TEXT columns (Post) continue to store plain HTML, no behaviour change

## Motivation
AppSignal shows p95 transaction_duration spiking above 3s on `Panda::CMS::PagesController#show`. The RichTextComponent re-parses raw EditorJS JSON on every page view to extract footnotes, even though this data was already computed during `generate_cached_content`. This eliminates that runtime parsing.

## Test plan
- [x] All 139 panda-editor tests pass
- [x] All 1085 panda-cms tests pass (862 unit + 223 system)
- [ ] Pair with corresponding panda-cms PR to read the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)