### PR TITLE
Fix ConfigHelper autoload timing during engine boot

### DIFF
--- a/lib/panda/editor/engine.rb
+++ b/lib/panda/editor/engine.rb
@@ -33,11 +33,11 @@ module Panda
         app.config.assets.precompile += %w[panda/editor/*.js panda/editor/*.css]
       end
 
-      # Make config helper available to all views (including panda-cms admin views)
-      initializer "panda_editor.helpers" do
-        ActiveSupport.on_load(:action_controller_base) do
-          helper Panda::Editor::ConfigHelper
-        end
+      # Make config helper available to all views (including panda-cms admin views).
+      # Use to_prepare so constant resolution happens after Zeitwerk has set up
+      # the engine's autoload paths (initializer + on_load fires too early).
+      config.to_prepare do
+        ActionController::Base.helper(Panda::Editor::ConfigHelper)
       end
 
       # Create a separate importmap for panda-editor


### PR DESCRIPTION
## Summary

Fixes `NameError: uninitialized constant Panda::Editor::ConfigHelper` during Rails boot.

## Root Cause

The initializer used `ActiveSupport.on_load(:action_controller_base)` to register the helper, but this callback fires before Zeitwerk has set up the engine's autoload paths. The constant `Panda::Editor::ConfigHelper` can't be resolved at that point.

## Fix

Replace the initializer + `on_load` pattern with `config.to_prepare`, which runs after Zeitwerk has fully configured autoload paths for all engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)